### PR TITLE
Multiple process support (#185)

### DIFF
--- a/lost-sample/src/main/AndroidManifest.xml
+++ b/lost-sample/src/main/AndroidManifest.xml
@@ -48,5 +48,6 @@
       </intent-filter>
     </service>
 
+
   </application>
 </manifest>

--- a/lost-sample/src/main/java/com/example/lost/LocationListenerActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/LocationListenerActivity.java
@@ -142,8 +142,7 @@ public class LocationListenerActivity extends AppCompatActivity  implements
 
     if (prefs.getBoolean(getString(R.string.mock_mode_gpx_key), false)) {
       String filename = prefs.getString(getString(R.string.mock_gpx_file_key), null);
-      File file = new File(getExternalFilesDir(null), filename);
-      FusedLocationApi.setMockTrace(client, file);
+      FusedLocationApi.setMockTrace(client, getExternalFilesDir(null).getPath(), filename);
     }
 
     final Resources res = getResources();
@@ -357,4 +356,3 @@ public class LocationListenerActivity extends AppCompatActivity  implements
     }
   }
 }
-

--- a/lost-sample/src/main/java/com/example/lost/PendingIntentActivity.java
+++ b/lost-sample/src/main/java/com/example/lost/PendingIntentActivity.java
@@ -54,7 +54,7 @@ public class PendingIntentActivity extends LostApiClientActivity {
 
   private void requestLocationUpdates() {
     LocationRequest request = LocationRequest.create();
-    request.setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
+    request.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
     request.setInterval(100);
 
     Intent intent = new Intent(PendingIntentService.ACTION);

--- a/lost/src/main/AndroidManifest.xml
+++ b/lost/src/main/AndroidManifest.xml
@@ -16,7 +16,9 @@
 
   <application>
 
-    <service android:name="com.mapzen.android.lost.internal.FusedLocationProviderService"/>
+    <service
+        android:name="com.mapzen.android.lost.internal.FusedLocationProviderService"
+        android:process=":lost"/>
     <service android:name="com.mapzen.android.lost.internal.GeofencingIntentService">
       <intent-filter>
         <action android:name="com.mapzen.lost.action.ACTION_GEOFENCING_SERVICE"/>

--- a/lost/src/main/aidl/com/mapzen/android/lost/api/LocationAvailability.aidl
+++ b/lost/src/main/aidl/com/mapzen/android/lost/api/LocationAvailability.aidl
@@ -1,0 +1,3 @@
+package com.mapzen.android.lost.api;
+
+parcelable LocationAvailability;

--- a/lost/src/main/aidl/com/mapzen/android/lost/api/LocationRequest.aidl
+++ b/lost/src/main/aidl/com/mapzen/android/lost/api/LocationRequest.aidl
@@ -1,0 +1,3 @@
+package com.mapzen.android.lost.api;
+
+parcelable LocationRequest;

--- a/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderCallback.aidl
+++ b/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderCallback.aidl
@@ -1,0 +1,10 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.LocationAvailability;
+
+interface IFusedLocationProviderCallback {
+
+  void onLocationChanged(in Location location);
+
+  void onLocationAvailabilityChanged(in LocationAvailability locationAvailability);
+}

--- a/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderService.aidl
+++ b/lost/src/main/aidl/com/mapzen/android/lost/internal/IFusedLocationProviderService.aidl
@@ -1,0 +1,24 @@
+package com.mapzen.android.lost.internal;
+
+import com.mapzen.android.lost.api.LocationAvailability;
+import com.mapzen.android.lost.api.LocationRequest;
+import com.mapzen.android.lost.internal.IFusedLocationProviderCallback;
+
+interface IFusedLocationProviderService {
+
+  void init(in IFusedLocationProviderCallback callback);
+
+  Location getLastLocation();
+
+  LocationAvailability getLocationAvailability();
+
+  void requestLocationUpdates(in LocationRequest request);
+
+  void removeLocationUpdates();
+
+  void setMockMode(boolean isMockMode);
+
+  void setMockLocation(in Location mockLocation);
+
+  void setMockTrace(String path, String filename);
+}

--- a/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
+++ b/lost/src/main/java/com/mapzen/android/lost/api/FusedLocationProviderApi.java
@@ -5,8 +5,6 @@ import android.location.Location;
 import android.os.Looper;
 import android.support.annotation.RequiresPermission;
 
-import java.io.File;
-
 import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
 import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 
@@ -169,7 +167,7 @@ public interface FusedLocationProviderApi {
    * This effects all {@link LostApiClient}s connected to the {@link FusedLocationProviderApi}.
    * Mock mode must be enabled before clients are able to call
    * {@link FusedLocationProviderApi#setMockLocation(LostApiClient, Location)} and
-   * {@link FusedLocationProviderApi#setMockTrace(LostApiClient, File)}
+   * {@link FusedLocationProviderApi#setMockTrace(LostApiClient, String, String)}
    *
    * @param client Connected client.
    * @param isMockMode Whether mock mode should be enabled or not.
@@ -196,9 +194,11 @@ public interface FusedLocationProviderApi {
    * Mock mode must be enabled before calling this method.
    *
    * @param client Connected client.
-   * @param file GPX file to be used to report location.
+   * @param path storage directory containing GPX trace to be used to report location.
+   * @param filename filename of GPX trace to be used to report location.
    * @return a {@link PendingResult} for the call to check whether call was successful.
    * @throws IllegalStateException if the client is not connected at the time of this call.
    */
-  PendingResult<Status> setMockTrace(LostApiClient client, final File file);
+  PendingResult<Status> setMockTrace(LostApiClient client, final String path,
+      final String filename);
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusedLocationProviderService.java
@@ -6,31 +6,52 @@ import com.mapzen.android.lost.api.LocationRequest;
 import android.app.Service;
 import android.content.Intent;
 import android.location.Location;
-import android.os.Binder;
 import android.os.IBinder;
+import android.os.RemoteException;
 import android.support.annotation.Nullable;
-import android.support.annotation.RequiresPermission;
-
-import java.io.File;
-
-import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
-import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 
 /**
  * Service which runs the fused location provider in the background.
  */
 public class FusedLocationProviderService extends Service {
 
-  private FusedLocationProviderServiceDelegate serviceImpl;
+  private FusedLocationProviderServiceDelegate delegate;
 
-  private final IBinder binder = new FusedLocationProviderBinder();
+  private final IFusedLocationProviderService.Stub binder =
+      new IFusedLocationProviderService.Stub() {
+        @Override public void init(IFusedLocationProviderCallback callback) throws RemoteException {
+          delegate.init(callback);
+        }
 
-  public class FusedLocationProviderBinder extends Binder {
+        @Override public Location getLastLocation() throws RemoteException {
+          return delegate.getLastLocation();
+        }
 
-    public FusedLocationProviderService getService() {
-      return FusedLocationProviderService.this;
-    }
-  }
+        @Override public LocationAvailability getLocationAvailability() throws RemoteException {
+          return delegate.getLocationAvailability();
+        }
+
+        @Override public void requestLocationUpdates(LocationRequest request)
+            throws RemoteException {
+          delegate.requestLocationUpdates(request);
+        }
+
+        @Override public void removeLocationUpdates() throws RemoteException {
+          delegate.removeLocationUpdates();
+        }
+
+        @Override public void setMockMode(boolean isMockMode) throws RemoteException {
+          delegate.setMockMode(isMockMode);
+        }
+
+        @Override public void setMockLocation(Location mockLocation) throws RemoteException {
+          delegate.setMockLocation(mockLocation);
+        }
+
+        @Override public void setMockTrace(String path, String filename) throws RemoteException {
+          delegate.setMockTrace(path, filename);
+        }
+      };
 
   @Nullable @Override public IBinder onBind(Intent intent) {
     return binder;
@@ -38,35 +59,6 @@ public class FusedLocationProviderService extends Service {
 
   @Override public void onCreate() {
     super.onCreate();
-    serviceImpl = new FusedLocationProviderServiceDelegate(this, LostClientManager.shared());
-  }
-
-  public Location getLastLocation() {
-    return serviceImpl.getLastLocation();
-  }
-
-  @RequiresPermission(anyOf = {ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION})
-  public LocationAvailability getLocationAvailability() {
-    return serviceImpl.getLocationAvailability();
-  }
-
-  public void requestLocationUpdates(LocationRequest request) {
-    serviceImpl.requestLocationUpdates(request);
-  }
-
-  public void removeLocationUpdates() {
-    serviceImpl.removeLocationUpdates();
-  }
-
-  public void setMockMode(boolean isMockMode) {
-    serviceImpl.setMockMode(isMockMode);
-  }
-
-  public void setMockLocation(Location mockLocation) {
-    serviceImpl.setMockLocation(mockLocation);
-  }
-
-  public void setMockTrace(File file) {
-    serviceImpl.setMockTrace(file);
+    delegate = new FusedLocationProviderServiceDelegate(this);
   }
 }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/FusionEngine.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/FusionEngine.java
@@ -143,7 +143,7 @@ public class FusionEngine extends LocationEngine implements LocationListener {
 
   private void enableGps(long interval) throws SecurityException {
     try {
-      locationManager.requestLocationUpdates(GPS_PROVIDER, interval, 0, this);
+      locationManager.requestLocationUpdates(GPS_PROVIDER, interval, 0, this, getLooper());
     } catch (IllegalArgumentException e) {
       Log.e(TAG, "Unable to register for GPS updates.", e);
     }
@@ -151,7 +151,7 @@ public class FusionEngine extends LocationEngine implements LocationListener {
 
   private void enableNetwork(long interval) throws SecurityException {
     try {
-      locationManager.requestLocationUpdates(NETWORK_PROVIDER, interval, 0, this);
+      locationManager.requestLocationUpdates(NETWORK_PROVIDER, interval, 0, this, getLooper());
     } catch (IllegalArgumentException e) {
       Log.e(TAG, "Unable to register for network updates.", e);
     }
@@ -159,7 +159,7 @@ public class FusionEngine extends LocationEngine implements LocationListener {
 
   private void enablePassive(long interval) throws SecurityException {
     try {
-      locationManager.requestLocationUpdates(PASSIVE_PROVIDER, interval, 0, this);
+      locationManager.requestLocationUpdates(PASSIVE_PROVIDER, interval, 0, this, getLooper());
     } catch (IllegalArgumentException e) {
       Log.e(TAG, "Unable to register for passive updates.", e);
     }

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LocationEngine.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LocationEngine.java
@@ -6,6 +6,7 @@ import com.mapzen.android.lost.api.LocationRequest;
 import android.content.Context;
 import android.location.Location;
 import android.location.LocationManager;
+import android.os.Looper;
 import android.support.annotation.RequiresPermission;
 
 import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
@@ -63,6 +64,10 @@ public abstract class LocationEngine {
 
   protected Context getContext() {
     return context;
+  }
+
+  protected Looper getLooper() {
+    return context.getMainLooper();
   }
 
   protected Callback getCallback() {

--- a/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
+++ b/lost/src/main/java/com/mapzen/android/lost/internal/LostClientManager.java
@@ -288,17 +288,17 @@ public class LostClientManager implements ClientManager {
           Long lastReportedTime = reportedChanges.timeChanges().get(request);
           Location lastReportedLocation = reportedChanges.locationChanges().get(request);
           if (lastReportedTime == null && lastReportedLocation == null) {
-            updatedRequestToReportedTime.put(request, System.currentTimeMillis());
+            updatedRequestToReportedTime.put(request, location.getTime());
             updatedRequestToReportedLocation.put(request, location);
             notifier.notify(client, obj);
           } else {
-            long intervalSinceLastReport = System.currentTimeMillis() - lastReportedTime;
+            long intervalSinceLastReport = location.getTime() - lastReportedTime;
             long fastestInterval = request.getFastestInterval();
             float smallestDisplacement = request.getSmallestDisplacement();
             float displacementSinceLastReport = location.distanceTo(lastReportedLocation);
             if (intervalSinceLastReport >= fastestInterval &&
                 displacementSinceLastReport >= smallestDisplacement) {
-              updatedRequestToReportedTime.put(request, System.currentTimeMillis());
+              updatedRequestToReportedTime.put(request, location.getTime());
               updatedRequestToReportedLocation.put(request, location);
               notifier.notify(client, obj);
             }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderApiImplTest.java
@@ -26,7 +26,6 @@ import android.location.Location;
 import android.os.Looper;
 import android.support.annotation.NonNull;
 
-import java.io.File;
 import java.util.concurrent.TimeUnit;
 
 import static org.fest.assertions.api.Assertions.assertThat;
@@ -36,9 +35,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.robolectric.RuntimeEnvironment.application;
-import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricTestRunner.class)
 @SuppressWarnings("MissingPermission")
@@ -48,11 +45,11 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
   private LostApiClient connectedClient;
   private LostApiClient disconnectedClient;
   private FusedLocationProviderApiImpl api;
-  private FusedLocationProviderService service;
+  private IFusedLocationProviderService service = mock(IFusedLocationProviderService.class);
   private FusedLocationServiceConnectionManager connectionManager;
 
   @Before public void setUp() throws Exception {
-    mockService();
+    LostClientManager.shared().clearClients();
     connectedClient = new LostApiClient.Builder(RuntimeEnvironment.application).build();
     connectedClient.connect();
 
@@ -66,15 +63,7 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
         LostApiClient.ConnectionCallbacks.class));
     api = new FusedLocationProviderApiImpl(connectionManager);
     api.connect(application, null);
-    service = api.getService();
-  }
-
-  private void mockService() {
-    FusedLocationProviderService.FusedLocationProviderBinder stubBinder = mock(
-        FusedLocationProviderService.FusedLocationProviderBinder.class);
-    when(stubBinder.getService()).thenReturn(mock(FusedLocationProviderService.class));
-    shadowOf(application).setComponentNameAndServiceForBindService(
-        new ComponentName("com.mapzen.lost", "FusedLocationProviderService"), stubBinder);
+    api.service = service;
   }
 
   @Test public void disconnect_shouldBeHarmlessBeforeConnect() {
@@ -122,17 +111,9 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
     api.getLastLocation(connectedClient);
   }
 
-  @Test public void getLastLocation_shouldCallService() {
-    new LostApiClient.Builder(mock(Context.class))
-        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
-          @Override public void onConnected() {
-            api.getLastLocation(connectedClient);
-            verify(service).getLastLocation();
-          }
-
-          @Override public void onConnectionSuspended() {
-          }
-        }).build().connect();
+  @Test public void getLastLocation_shouldCallService() throws Exception {
+    api.getLastLocation(connectedClient);
+    verify(service).getLastLocation();
   }
 
   @Test(expected = IllegalStateException.class)
@@ -141,17 +122,9 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
     api.getLocationAvailability(connectedClient);
   }
 
-  @Test public void getLocationAvailability_shouldCallService() {
-    new LostApiClient.Builder(mock(Context.class))
-        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
-          @Override public void onConnected() {
-            api.getLocationAvailability(connectedClient);
-            verify(service).getLocationAvailability();
-          }
-
-          @Override public void onConnectionSuspended() {
-          }
-        }).build().connect();
+  @Test public void getLocationAvailability_shouldCallService() throws Exception {
+    api.getLocationAvailability(connectedClient);
+    verify(service).getLocationAvailability();
   }
 
   @Test(expected = IllegalStateException.class)
@@ -175,50 +148,26 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
         new TestLocationCallback(), Looper.myLooper());
   }
 
-  @Test public void requestLocationUpdates_listener_shouldCallService() {
-    new LostApiClient.Builder(mock(Context.class))
-        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
-          @Override public void onConnected() {
-            LocationRequest request = LocationRequest.create();
-            LocationListener listener = new TestLocationListener();
-            api.requestLocationUpdates(connectedClient, request, listener);
-            verify(service).requestLocationUpdates(request);
-          }
-
-          @Override public void onConnectionSuspended() {
-          }
-        }).build().connect();
+  @Test public void requestLocationUpdates_listener_shouldCallService() throws Exception {
+    LocationRequest request = LocationRequest.create();
+    LocationListener listener = new TestLocationListener();
+    api.requestLocationUpdates(connectedClient, request, listener);
+    verify(service).requestLocationUpdates(request);
   }
 
-  @Test public void requestLocationUpdates_pendingIntent_shouldCallService() {
-    new LostApiClient.Builder(mock(Context.class))
-        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
-          @Override public void onConnected() {
-            LocationRequest request = LocationRequest.create();
-            PendingIntent pendingIntent = mock(PendingIntent.class);
-            api.requestLocationUpdates(connectedClient, request, pendingIntent);
-            verify(service).requestLocationUpdates(request);
-          }
-
-          @Override public void onConnectionSuspended() {
-          }
-        }).build().connect();
+  @Test public void requestLocationUpdates_pendingIntent_shouldCallService() throws Exception {
+    LocationRequest request = LocationRequest.create();
+    PendingIntent pendingIntent = mock(PendingIntent.class);
+    api.requestLocationUpdates(connectedClient, request, pendingIntent);
+    verify(service).requestLocationUpdates(request);
   }
 
-  @Test public void requestLocationUpdates_callback_shouldCallService() {
-    new LostApiClient.Builder(mock(Context.class))
-        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
-          @Override public void onConnected() {
-            LocationRequest request = LocationRequest.create();
-            TestLocationCallback callback = new TestLocationCallback();
-            Looper looper = Looper.myLooper();
-            api.requestLocationUpdates(connectedClient, request, callback, looper);
-            verify(service).requestLocationUpdates(request);
-          }
-
-          @Override public void onConnectionSuspended() {
-          }
-        }).build().connect();
+  @Test public void requestLocationUpdates_callback_shouldCallService() throws Exception {
+    LocationRequest request = LocationRequest.create();
+    TestLocationCallback callback = new TestLocationCallback();
+    Looper looper = Looper.myLooper();
+    api.requestLocationUpdates(connectedClient, request, callback, looper);
+    verify(service).requestLocationUpdates(request);
   }
 
   @Test(expected = RuntimeException.class)
@@ -246,46 +195,22 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
     api.removeLocationUpdates(connectedClient, new TestLocationCallback());
   }
 
-  @Test public void removeLocationUpdates_listener_shouldCallService() {
-    new LostApiClient.Builder(mock(Context.class))
-        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
-          @Override public void onConnected() {
-            LocationListener listener = new TestLocationListener();
-            api.removeLocationUpdates(connectedClient, listener);
-            verify(service).removeLocationUpdates();
-          }
-
-          @Override public void onConnectionSuspended() {
-          }
-        }).build().connect();
+  @Test public void removeLocationUpdates_listener_shouldCallService() throws Exception {
+    LocationListener listener = new TestLocationListener();
+    api.removeLocationUpdates(connectedClient, listener);
+    verify(service).removeLocationUpdates();
   }
 
-  @Test public void removeLocationUpdates_pendingIntent_shouldCallService() {
-    new LostApiClient.Builder(mock(Context.class))
-        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
-          @Override public void onConnected() {
-            PendingIntent callbackIntent = mock(PendingIntent.class);
-            api.removeLocationUpdates(connectedClient, callbackIntent);
-            verify(service).removeLocationUpdates();
-          }
-
-          @Override public void onConnectionSuspended() {
-          }
-        }).build().connect();
+  @Test public void removeLocationUpdates_pendingIntent_shouldCallService() throws Exception {
+    PendingIntent callbackIntent = mock(PendingIntent.class);
+    api.removeLocationUpdates(connectedClient, callbackIntent);
+    verify(service).removeLocationUpdates();
   }
 
-  @Test public void removeLocationUpdates_callback_shouldCallService() {
-    new LostApiClient.Builder(mock(Context.class))
-        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
-          @Override public void onConnected() {
-            TestLocationCallback callback = new TestLocationCallback();
-            api.removeLocationUpdates(connectedClient, callback);
-            verify(service).removeLocationUpdates();
-          }
-
-          @Override public void onConnectionSuspended() {
-          }
-        }).build().connect();
+  @Test public void removeLocationUpdates_callback_shouldCallService() throws Exception {
+    TestLocationCallback callback = new TestLocationCallback();
+    api.removeLocationUpdates(connectedClient, callback);
+    verify(service).removeLocationUpdates();
   }
 
   @Test(expected = IllegalStateException.class)
@@ -303,48 +228,23 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
   @Test(expected = IllegalStateException.class)
   public void setMockTrace_shouldThrowIfNotConnected() throws Exception {
     connectedClient.disconnect();
-    api.setMockTrace(connectedClient, new File("path", "name"));
+    api.setMockTrace(connectedClient, "path", "name");
   }
 
-  @Test public void setMockMode_shouldCallService() {
-    new LostApiClient.Builder(mock(Context.class))
-        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
-          @Override public void onConnected() {
-            api.setMockMode(connectedClient, true);
-            verify(service).setMockMode(true);
-          }
-
-          @Override public void onConnectionSuspended() {
-          }
-        }).build().connect();
+  @Test public void setMockMode_shouldCallService() throws Exception {
+    api.setMockMode(connectedClient, true);
+    verify(service).setMockMode(true);
   }
 
-  @Test public void setMockLocation_shouldCallService() {
-    new LostApiClient.Builder(mock(Context.class))
-        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
-          @Override public void onConnected() {
-            Location location = new Location("test");
-            api.setMockLocation(connectedClient, location);
-            verify(service).setMockLocation(location);
-          }
-
-          @Override public void onConnectionSuspended() {
-          }
-        }).build().connect();
+  @Test public void setMockLocation_shouldCallService() throws Exception {
+    Location location = new Location("test");
+    api.setMockLocation(connectedClient, location);
+    verify(service).setMockLocation(location);
   }
 
-  @Test public void setMockTrace_shouldCallService() {
-    new LostApiClient.Builder(mock(Context.class))
-        .addConnectionCallbacks(new LostApiClient.ConnectionCallbacks() {
-          @Override public void onConnected() {
-            File file = new File("path", "name");
-            api.setMockTrace(connectedClient, file);
-            verify(service).setMockTrace(file);
-          }
-
-          @Override public void onConnectionSuspended() {
-          }
-        }).build().connect();
+  @Test public void setMockTrace_shouldCallService() throws Exception {
+    api.setMockTrace(connectedClient, "path", "name");
+    verify(service).setMockTrace("path", "name");
   }
 
   @Test public void onConnect_shouldStartService() throws Exception {
@@ -449,6 +349,24 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
     assertThat(api.getLocationListeners().get(otherClient).size()).isEqualTo(1);
   }
 
+  @Test public void removeLocationUpdates_shouldKillEngineIfNoListenersStillActive()
+      throws Exception {
+    TestLocationListener listener = new TestLocationListener();
+    api.requestLocationUpdates(connectedClient, LocationRequest.create(), listener);
+    api.removeLocationUpdates(connectedClient, listener);
+    verify(service).removeLocationUpdates();
+  }
+
+  @Test public void removeLocationUpdates_shouldNotKillEngineIfListenerStillActive()
+      throws Exception {
+    TestLocationListener listener1 = new TestLocationListener();
+    TestLocationListener listener2 = new TestLocationListener();
+    api.requestLocationUpdates(connectedClient, LocationRequest.create(), listener1);
+    api.requestLocationUpdates(connectedClient, LocationRequest.create(), listener2);
+    api.removeLocationUpdates(connectedClient, listener1);
+    verify(service, never()).removeLocationUpdates();
+  }
+
   @Test public void requestLocationUpdates_listener_shouldReturnFusedLocationPendingResult() {
     PendingResult<Status> result = api.requestLocationUpdates(connectedClient,
         LocationRequest.create(), new TestLocationListener());
@@ -533,7 +451,7 @@ public class FusedLocationProviderApiImplTest extends BaseRobolectricTest {
   }
 
   @Test public void setMockTrace_shouldReturnFusedLocationPendingResult() {
-    PendingResult<Status> result = api.setMockTrace(connectedClient, new File("test"));
+    PendingResult<Status> result = api.setMockTrace(connectedClient, "path", "name");
     assertThat(result.await().getStatus().getStatusCode()).isEqualTo(Status.SUCCESS);
     assertThat(result.await(1000, TimeUnit.MILLISECONDS).getStatus().getStatusCode()).isEqualTo(
         Status.SUCCESS);

--- a/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegateTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/FusedLocationProviderServiceDelegateTest.java
@@ -3,7 +3,6 @@ package com.mapzen.android.lost.internal;
 import com.mapzen.android.lost.BaseRobolectricTest;
 import com.mapzen.android.lost.api.LocationAvailability;
 import com.mapzen.android.lost.api.LocationRequest;
-import com.mapzen.android.lost.api.LocationResult;
 import com.mapzen.android.lost.api.LostApiClient;
 import com.mapzen.android.lost.shadows.LostShadowLocationManager;
 import com.mapzen.lost.BuildConfig;
@@ -18,19 +17,17 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.internal.ShadowExtractor;
-import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowEnvironment;
 import org.robolectric.shadows.ShadowLooper;
 
 import android.app.IntentService;
-import android.app.PendingIntent;
-import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.location.Location;
 import android.location.LocationManager;
 import android.os.Environment;
-import android.os.Looper;
+import android.os.IBinder;
+import android.os.RemoteException;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -39,14 +36,13 @@ import java.io.IOException;
 import static android.content.Context.LOCATION_SERVICE;
 import static android.location.LocationManager.GPS_PROVIDER;
 import static android.location.LocationManager.NETWORK_PROVIDER;
-import static com.mapzen.android.lost.api.FusedLocationProviderApi.KEY_LOCATION_CHANGED;
 import static com.mapzen.android.lost.api.LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY;
 import static com.mapzen.android.lost.api.LocationRequest.PRIORITY_HIGH_ACCURACY;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.robolectric.RuntimeEnvironment.application;
-import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricTestRunner.class)
 @SuppressWarnings("MissingPermission")
@@ -54,19 +50,15 @@ import static org.robolectric.Shadows.shadowOf;
         LostShadowLocationManager.class})
 public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTest {
   private LostApiClient client;
-  private FusedLocationProviderServiceDelegate api;
+  private FusedLocationProviderServiceDelegate delegate;
   private LocationManager locationManager;
   private LostShadowLocationManager shadowLocationManager;
   private LostApiClient otherClient;
-  private ClientManager clientManager;
 
   @Before public void setUp() throws Exception {
-
-    mockService();
     client = new LostApiClient.Builder(mock(Context.class)).build();
     otherClient = new LostApiClient.Builder(mock(Context.class)).build();
-    clientManager = LostClientManager.shared();
-    api = new FusedLocationProviderServiceDelegate(application, clientManager);
+    delegate = new FusedLocationProviderServiceDelegate(application);
     locationManager = (LocationManager) application.getSystemService(LOCATION_SERVICE);
     shadowLocationManager = (LostShadowLocationManager) ShadowExtractor.extract(locationManager);
     client.connect();
@@ -77,261 +69,129 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     otherClient.disconnect();
   }
 
-  private void mockService() {
-    FusedLocationProviderService.FusedLocationProviderBinder stubBinder =
-        mock(FusedLocationProviderService.FusedLocationProviderBinder.class);
-    when(stubBinder.getService()).thenReturn(mock(FusedLocationProviderService.class));
-    shadowOf(application).setComponentNameAndServiceForBindService(
-        new ComponentName("com.mapzen.lost", "FusedLocationProviderService"), stubBinder);
-  }
-
   @Test public void shouldNotBeNull() throws Exception {
-    assertThat(api).isNotNull();
+    assertThat(delegate).isNotNull();
   }
 
   @Test public void getLastLocation_shouldReturnMostRecentLocation() throws Exception {
     Location location = new Location(GPS_PROVIDER);
     shadowLocationManager.setLastKnownLocation(GPS_PROVIDER, location);
-    assertThat(api.getLastLocation()).isNotNull();
+    assertThat(delegate.getLastLocation()).isNotNull();
   }
 
   @Test public void requestLocationUpdates_shouldRegisterGpsAndNetworkListener() throws Exception {
-    api.requestLocationUpdates(LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY));
+    delegate.requestLocationUpdates(LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY));
     assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).hasSize(2);
   }
 
   @Test public void requestLocationUpdates_shouldNotifyOnLocationChangedGps() throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
+    TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
+    delegate.init(callback);
+    delegate.requestLocationUpdates(LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY));
+
     Location location = new Location(GPS_PROVIDER);
     shadowLocationManager.simulateLocation(location);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(location);
+    assertThat(callback.location).isEqualTo(location);
   }
 
   @Test public void requestLocationUpdates_shouldNotifyOnLocationChangedNetwork() throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    api.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addListener(client, LocationRequest.create(), listener);
+    TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
+    delegate.init(callback);
+    delegate.requestLocationUpdates(LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY));
+
     Location location = new Location(NETWORK_PROVIDER);
     shadowLocationManager.simulateLocation(location);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(location);
+    assertThat(callback.location).isEqualTo(location);
   }
 
-  @Test public void requestLocationUpdates_shouldNotNotifyIfLessThanFastestIntervalGps()
-      throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-    request.setFastestInterval(5000);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
+  @Test public void requestLocationUpdates_shouldPreferGpsIfMoreAccurate() throws Exception {
+    TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
+    delegate.init(callback);
+    delegate.requestLocationUpdates(LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY));
 
-    final long time = System.currentTimeMillis();
-    Location location1 = getTestLocation(GPS_PROVIDER, 0, 0, time);
-    Location location2 = getTestLocation(GPS_PROVIDER, 1, 1, time + 1000);
-
-    shadowLocationManager.simulateLocation(location1);
-    shadowLocationManager.simulateLocation(location2);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(location1);
-  }
-
-  @Test public void requestLocationUpdates_shouldNotNotifyIfLessThanFastestIntervalNetwork()
-      throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(5000);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
-
-    final long time = System.currentTimeMillis();
-    Location location1 = getTestLocation(NETWORK_PROVIDER, 0, 0, time);
-    Location location2 = getTestLocation(NETWORK_PROVIDER, 1, 1, time + 1000);
-
-    shadowLocationManager.simulateLocation(location1);
-    shadowLocationManager.simulateLocation(location2);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(location1);
-  }
-
-  @Test public void requestLocationUpdates_shouldNotNotifyIfLessThanSmallestDisplacementGps()
-      throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-    request.setSmallestDisplacement(200000);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
-
-    final long time = System.currentTimeMillis();
-    Location location1 = getTestLocation(GPS_PROVIDER, 0, 0, time);
-    Location location2 = getTestLocation(GPS_PROVIDER, 1, 1, time + 1000);
-
-    shadowLocationManager.simulateLocation(location1);
-    shadowLocationManager.simulateLocation(location2);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(location1);
-  }
-
-  @Test public void requestLocationUpdates_shouldNotNotifyIfLessThanSmallestDisplacementNetwork()
-      throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create();
-    request.setSmallestDisplacement(200000);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
-
-    final long time = System.currentTimeMillis();
-    Location location1 = getTestLocation(NETWORK_PROVIDER, 0, 0, time);
-    Location location2 = getTestLocation(NETWORK_PROVIDER, 1, 1, time + 1000);
-
-    shadowLocationManager.simulateLocation(location1);
-    shadowLocationManager.simulateLocation(location2);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(location1);
-  }
-
-  @Test public void requestLocationUpdates_shouldIgnoreNetworkWhenGpsIsMoreAccurate()
-      throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-    request.setFastestInterval(0);
-    request.setSmallestDisplacement(0);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
-
-    final long time = System.currentTimeMillis();
-    Location gpsLocation = getTestLocation(GPS_PROVIDER, 0, 0, time);
-    Location networkLocation = getTestLocation(NETWORK_PROVIDER, 0, 0, time + 1);
+    Location gpsLocation = getTestLocation(GPS_PROVIDER, 0, 0, 0);
+    Location networkLocation = getTestLocation(NETWORK_PROVIDER, 0, 0, 0);
 
     gpsLocation.setAccuracy(10);
     networkLocation.setAccuracy(20);
     shadowLocationManager.simulateLocation(gpsLocation);
     shadowLocationManager.simulateLocation(networkLocation);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(gpsLocation);
+    assertThat(callback.location).isEqualTo(gpsLocation);
   }
 
-  @Test public void requestLocationUpdates_shouldIgnoreGpsWhenNetworkIsMoreAccurate()
-      throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(0);
-    request.setSmallestDisplacement(0);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
+  @Test public void requestLocationUpdates_shouldPreferNetworkIfMoreAccurate() throws Exception {
+    TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
+    delegate.init(callback);
+    delegate.requestLocationUpdates(LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY));
 
-    final long time = System.currentTimeMillis();
-    Location networkLocation = getTestLocation(NETWORK_PROVIDER, 0, 0, time);
-    Location gpsLocation = getTestLocation(GPS_PROVIDER, 0, 0, time + 1);
+    Location gpsLocation = getTestLocation(GPS_PROVIDER, 0, 0, 0);
+    Location networkLocation = getTestLocation(NETWORK_PROVIDER, 0, 0, 0);
 
-    networkLocation.setAccuracy(10);
     gpsLocation.setAccuracy(20);
+    networkLocation.setAccuracy(10);
     shadowLocationManager.simulateLocation(networkLocation);
     shadowLocationManager.simulateLocation(gpsLocation);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(networkLocation);
-  }
-
-  @Test public void requestLocationUpdates_shouldNotifyWithLocationAvailabilityInPendingIntent()
-      throws Exception {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    LocationRequest locationRequest =
-        LocationRequest.create().setPriority(PRIORITY_BALANCED_POWER_ACCURACY);
-    api.requestLocationUpdates(locationRequest);
-    LostClientManager.shared().addPendingIntent(client, locationRequest, pendingIntent);
-    Location location = new Location(NETWORK_PROVIDER);
-    shadowLocationManager.simulateLocation(location);
-    Intent nextStartedService = ShadowApplication.getInstance().getNextStartedService();
-    assertThat(nextStartedService).isNotNull();
-    assertThat(nextStartedService.getParcelableExtra(
-        LocationAvailability.EXTRA_LOCATION_AVAILABILITY)).isNotNull();
-  }
-
-  @Test public void requestLocationUpdates_shouldNotifyWithLocationResultInPendingIntent()
-      throws Exception {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    LocationRequest locationRequest =
-        LocationRequest.create().setPriority(PRIORITY_BALANCED_POWER_ACCURACY);
-
-    LostClientManager.shared().addPendingIntent(client, locationRequest, pendingIntent);
-    api.requestLocationUpdates(locationRequest);
-    Location location = new Location(NETWORK_PROVIDER);
-    shadowLocationManager.simulateLocation(location);
-
-    Intent nextStartedService = ShadowApplication.getInstance().getNextStartedService();
-    assertThat(nextStartedService).isNotNull();
-    assertThat(
-        nextStartedService.getParcelableExtra(LocationResult.EXTRA_LOCATION_RESULT)).isNotNull();
+    assertThat(callback.location).isEqualTo(networkLocation);
   }
 
   @Test public void removeLocationUpdates_shouldUnregisterAllListeners() throws Exception {
-    api.requestLocationUpdates(LocationRequest.create());
-    api.removeLocationUpdates();
+    delegate.requestLocationUpdates(LocationRequest.create());
+    delegate.removeLocationUpdates();
     assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).isEmpty();
   }
 
   @Test public void setMockMode_shouldUnregisterAllListenersWhenTrue() throws Exception {
     LocationRequest request = LocationRequest.create();
-    api.requestLocationUpdates(request);
-    api.setMockMode(true);
+    delegate.requestLocationUpdates(request);
+    delegate.setMockMode(true);
     assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).isEmpty();
   }
 
   @Test public void setMockMode_shouldNotRegisterDuplicateListeners() throws Exception {
     LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-    api.setMockMode(true);
-    api.requestLocationUpdates(request);
-    api.setMockMode(false);
-    api.requestLocationUpdates(request);
+    delegate.setMockMode(true);
+    delegate.requestLocationUpdates(request);
+    delegate.setMockMode(false);
+    delegate.requestLocationUpdates(request);
     assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).hasSize(2);
-  }
-
-  @Test public void setMockMode_shouldToggleEngines() {
-    TestLocationListener listener = new TestLocationListener();
-    LocationRequest request = LocationRequest.create();
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
-
-    api.setMockMode(true);
-    TestLocationListener listener2 = new TestLocationListener();
-    LocationRequest request2 = LocationRequest.create();
-    api.requestLocationUpdates(request2);
-    LostClientManager.shared().addListener(client, request2, listener2);
-
-    assertThat(clientManager.getLocationListeners().get(client)).hasSize(2);
   }
 
   @Test public void requestLocationUpdates_shouldNotRegisterListenersWithMockModeOn()
       throws Exception {
-    api.setMockMode(true);
+    delegate.setMockMode(true);
     LocationRequest request = LocationRequest.create();
-    api.requestLocationUpdates(request);
+    delegate.requestLocationUpdates(request);
     assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).isEmpty();
   }
 
   @Test public void setMockLocation_shouldReturnMockLastLocation() throws Exception {
     Location mockLocation = new Location("mock");
-    api.setMockMode(true);
-    api.setMockLocation(mockLocation);
-    assertThat(api.getLastLocation()).isEqualTo(mockLocation);
+    delegate.setMockMode(true);
+    delegate.setMockLocation(mockLocation);
+    assertThat(delegate.getLastLocation()).isEqualTo(mockLocation);
   }
 
-  @Test public void setMockLocation_shouldInvokeListenerOnce() throws Exception {
+  @Test public void setMockLocation_shouldCallbackOnce() throws Exception {
+    IFusedLocationProviderCallback callback = mock(IFusedLocationProviderCallback.class);
+    delegate.init(callback);
     Location mockLocation = new Location("mock");
-    api.setMockMode(true);
+    delegate.setMockMode(true);
     TestLocationListener listener = new TestLocationListener();
     LocationRequest request = LocationRequest.create();
-    api.requestLocationUpdates(request);
+    delegate.requestLocationUpdates(request);
     LostClientManager.shared().addListener(client, request, listener);
-    api.setMockLocation(mockLocation);
-    assertThat(listener.getAllLocations()).hasSize(1);
-    assertThat(listener.getMostRecentLocation()).isEqualTo(mockLocation);
+    delegate.setMockLocation(mockLocation);
+    verify(callback, times(1)).onLocationChanged(mockLocation);
   }
 
   public void setMockTrace_shouldInvokeListenerForEachLocation() throws Exception {
-    api.setMockMode(true);
-    api.setMockTrace(getTestGpxTrace());
+    initTestGpxTrace();
+    delegate.setMockMode(true);
+    delegate.setMockTrace(Environment.getExternalStorageDirectory().getPath(), "lost.gpx");
     TestLocationListener listener = new TestLocationListener();
     LocationRequest request = LocationRequest.create();
     request.setFastestInterval(0);
-    api.requestLocationUpdates(request);
+    delegate.requestLocationUpdates(request);
     Thread.sleep(100);
     ShadowLooper.runUiThreadTasks();
     assertThat(listener.getAllLocations()).hasSize(3);
@@ -344,12 +204,13 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
   }
 
   public void setMockTrace_shouldBroadcastSpeedWithLocation() throws Exception {
-    api.setMockMode(true);
-    api.setMockTrace(getTestGpxTrace());
+    initTestGpxTrace();
+    delegate.setMockMode(true);
+    delegate.setMockTrace(Environment.getExternalStorageDirectory().getPath(), "lost.gpx");
     TestLocationListener listener = new TestLocationListener();
     LocationRequest request = LocationRequest.create();
     request.setFastestInterval(0);
-    api.requestLocationUpdates(request);
+    delegate.requestLocationUpdates(request);
     Thread.sleep(100);
     ShadowLooper.runUiThreadTasks();
     assertThat(listener.getAllLocations().get(0).getSpeed()).isEqualTo(10f);
@@ -358,12 +219,13 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
   }
 
   public void setMockTrace_shouldRespectFastestInterval() throws Exception {
-    api.setMockMode(true);
-    api.setMockTrace(getTestGpxTrace());
+    initTestGpxTrace();
+    delegate.setMockMode(true);
+    delegate.setMockTrace(Environment.getExternalStorageDirectory().getPath(), "lost.gpx");
     TestLocationListener listener = new TestLocationListener();
     LocationRequest request = LocationRequest.create();
     request.setInterval(100);
-    api.requestLocationUpdates(request);
+    delegate.requestLocationUpdates(request);
     Thread.sleep(100);
     ShadowLooper.runUiThreadTasks();
     assertThat(listener.getAllLocations()).hasSize(1);
@@ -383,7 +245,7 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     return location;
   }
 
-  private File getTestGpxTrace() throws IOException {
+  private void initTestGpxTrace() throws IOException {
     String contents = Files.toString(new File("src/test/resources/lost.gpx"), Charsets.UTF_8);
     ShadowEnvironment.setExternalStorageState(Environment.MEDIA_MOUNTED);
     File directory = Environment.getExternalStorageDirectory();
@@ -391,130 +253,32 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     FileWriter fileWriter = new FileWriter(file, false);
     fileWriter.write(contents);
     fileWriter.close();
-    return file;
-  }
-
-  @Test public void requestLocationUpdates_shouldNotifyBothListeners() {
-    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-    TestLocationListener listener1 = new TestLocationListener();
-    TestLocationListener listener2 = new TestLocationListener();
-    api.requestLocationUpdates(request);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener1);
-    LostClientManager.shared().addListener(client, request, listener2);
-    Location location = new Location(GPS_PROVIDER);
-    location.setLatitude(40.0);
-    location.setLongitude(70.0);
-    shadowLocationManager.simulateLocation(location);
-    assertThat(listener1.getAllLocations()).contains(location);
-    assertThat(listener2.getAllLocations()).contains(location);
-  }
-
-  @Test public void requestLocationUpdates_shouldNotNotifyRemovedListener() {
-    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-    TestLocationListener listener1 = new TestLocationListener();
-    TestLocationListener listener2 = new TestLocationListener();
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener1);
-    LostClientManager.shared().addListener(client, request, listener2);
-    LostClientManager.shared().removeListener(client, listener2);
-    Location location = new Location(GPS_PROVIDER);
-    shadowLocationManager.simulateLocation(location);
-    assertThat(listener1.getAllLocations()).contains(location);
-    assertThat(listener2.getAllLocations()).doesNotContain(location);
   }
 
   @Test public void requestLocationUpdates_shouldRegisterGpsAndNetworkListenerViaPendingIntent()
       throws Exception {
-    api.requestLocationUpdates(LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY));
+    delegate.requestLocationUpdates(LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY));
     assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).hasSize(2);
-  }
-
-  @Test public void requestLocationUpdates_shouldNotifyOnLocationChangedGpsViaPendingIntent()
-      throws Exception {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    LocationRequest locationRequest = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-
-    LostClientManager.shared().addPendingIntent(client, locationRequest, pendingIntent);
-    api.requestLocationUpdates(locationRequest);
-    Location location = new Location(GPS_PROVIDER);
-    shadowLocationManager.simulateLocation(location);
-
-    Intent nextStartedService = ShadowApplication.getInstance().getNextStartedService();
-    assertThat(nextStartedService).isNotNull();
-    assertThat(nextStartedService.getParcelableExtra(KEY_LOCATION_CHANGED)).isEqualTo(location);
-  }
-
-  @Test public void requestLocationUpdates_shouldNotifyOnLocationChangedNetworkViaPendingIntent()
-      throws Exception {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    LocationRequest locationRequest =
-        LocationRequest.create().setPriority(PRIORITY_BALANCED_POWER_ACCURACY);
-
-    LostClientManager.shared().addPendingIntent(client, locationRequest, pendingIntent);
-    api.requestLocationUpdates(locationRequest);
-    Location location = new Location(NETWORK_PROVIDER);
-    shadowLocationManager.simulateLocation(location);
-
-    Intent nextStartedService = ShadowApplication.getInstance().getNextStartedService();
-    assertThat(nextStartedService).isNotNull();
-    assertThat(nextStartedService.getParcelableExtra(KEY_LOCATION_CHANGED)).isEqualTo(location);
   }
 
   @Test public void removeLocationUpdates_shouldUnregisterAllPendingIntentListeners()
       throws Exception {
     LocationRequest locationRequest =
         LocationRequest.create().setPriority(PRIORITY_BALANCED_POWER_ACCURACY);
-    api.requestLocationUpdates(locationRequest);
-    api.removeLocationUpdates();
+    delegate.requestLocationUpdates(locationRequest);
+    delegate.removeLocationUpdates();
     assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).isEmpty();
   }
 
-  @Test public void requestLocationUpdates_shouldNotNotifyRemovedPendingIntent() throws Exception {
-    LocationRequest request = LocationRequest.create().setPriority(PRIORITY_HIGH_ACCURACY);
-    Intent intent1 = new Intent(application, TestService.class);
-    Intent intent2 = new Intent(application, OtherTestService.class);
-    PendingIntent pendingIntent1 = PendingIntent.getService(application, 0, intent1, 0);
-    PendingIntent pendingIntent2 = PendingIntent.getService(application, 0, intent2, 0);
-    api.requestLocationUpdates(request);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addPendingIntent(client, request, pendingIntent1);
-    LostClientManager.shared().addPendingIntent(client, request, pendingIntent2);
-
-    LostClientManager.shared().removePendingIntent(client, pendingIntent2);
-    Location location = new Location(GPS_PROVIDER);
-    location.setLatitude(40.0);
-    location.setLongitude(70.0);
-    shadowLocationManager.simulateLocation(location);
-
-    // Only one service should be started since the second pending intent request was removed.
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNull();
-  }
-
-  @Test public void requestLocationUpdates_shouldReportResult() {
-    TestLocationCallback callback = new TestLocationCallback();
-    Looper looper = Looper.myLooper();
-    LocationRequest request = LocationRequest.create();
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addLocationCallback(client, request, callback, looper);
-    Location location = getTestLocation(NETWORK_PROVIDER, 0, 0, 0);
-    shadowLocationManager.simulateLocation(location);
-    assertThat(callback.getResult().getLastLocation()).isEqualTo(location);
-  }
-
   @Test public void requestLocationUpdates_shouldReportAvailability() {
+    TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
+    delegate.init(callback);
     Location location = new Location("test");
     shadowLocationManager.setLastKnownLocation(NETWORK_PROVIDER, location);
-    TestLocationCallback callback = new TestLocationCallback();
-    Looper looper = Looper.myLooper();
     LocationRequest request = LocationRequest.create();
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addLocationCallback(client, request, callback, looper);
+    delegate.requestLocationUpdates(request);
     shadowLocationManager.setProviderEnabled(NETWORK_PROVIDER, true);
-    assertThat(callback.getAvailability().isLocationAvailable()).isEqualTo(true);
+    assertThat(callback.locationAvailability.isLocationAvailable()).isTrue();
   }
 
   @Test public void getLocationAvailability_gps_network_shouldBeAvailable() {
@@ -523,7 +287,7 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     Location location = new Location("test");
     shadowLocationManager.setLastKnownLocation(GPS_PROVIDER, location);
 
-    LocationAvailability availability = api.getLocationAvailability();
+    LocationAvailability availability = delegate.getLocationAvailability();
     assertThat(availability.isLocationAvailable()).isTrue();
   }
 
@@ -531,7 +295,7 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     shadowLocationManager.setProviderEnabled(GPS_PROVIDER, true);
     shadowLocationManager.setProviderEnabled(NETWORK_PROVIDER, true);
 
-    LocationAvailability availability = api.getLocationAvailability();
+    LocationAvailability availability = delegate.getLocationAvailability();
     assertThat(availability.isLocationAvailable()).isFalse();
   }
 
@@ -540,14 +304,14 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     Location location = new Location("test");
     shadowLocationManager.setLastKnownLocation(GPS_PROVIDER, location);
 
-    LocationAvailability availability = api.getLocationAvailability();
+    LocationAvailability availability = delegate.getLocationAvailability();
     assertThat(availability.isLocationAvailable()).isTrue();
   }
 
   @Test public void getLocationAvailability_gps_shouldBeUnavailable() {
     shadowLocationManager.setProviderEnabled(GPS_PROVIDER, true);
 
-    LocationAvailability availability = api.getLocationAvailability();
+    LocationAvailability availability = delegate.getLocationAvailability();
     assertThat(availability.isLocationAvailable()).isFalse();
   }
 
@@ -556,517 +320,34 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     Location location = new Location("test");
     shadowLocationManager.setLastKnownLocation(NETWORK_PROVIDER, location);
 
-    LocationAvailability availability = api.getLocationAvailability();
+    LocationAvailability availability = delegate.getLocationAvailability();
     assertThat(availability.isLocationAvailable()).isTrue();
   }
 
   @Test public void getLocationAvailability_network_shouldBeUnavailable() {
     shadowLocationManager.setProviderEnabled(NETWORK_PROVIDER, true);
 
-    LocationAvailability availability = api.getLocationAvailability();
+    LocationAvailability availability = delegate.getLocationAvailability();
     assertThat(availability.isLocationAvailable()).isFalse();
   }
 
   @Test public void getLocationAvailability_shouldBeUnavailable() {
-    LocationAvailability availability = api.getLocationAvailability();
+    LocationAvailability availability = delegate.getLocationAvailability();
     assertThat(availability.isLocationAvailable()).isFalse();
-  }
-
-  @Test public void removeLocationUpdates_shouldNotKillEngineIfListenerStillActive()
-      throws Exception {
-    TestLocationListener listener = new TestLocationListener();
-    api.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addListener(client, LocationRequest.create(), listener);
-    api.requestLocationUpdates(LocationRequest.create());
-    api.removeLocationUpdates();
-    assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).isNotEmpty();
-  }
-
-  @Test public void removeLocationUpdates_shouldNotKillEngineIfIntentStillActive()
-      throws Exception {
-    api.requestLocationUpdates(LocationRequest.create());
-
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, new Intent(), 0);
-    api.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addPendingIntent(client, LocationRequest.create(), pendingIntent);
-
-    api.removeLocationUpdates();
-    assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).isNotEmpty();
   }
 
   @Test public void removeLocationUpdates_locationCallback_shouldUnregisterAllListeners() {
     LocationRequest request = LocationRequest.create();
-    api.requestLocationUpdates(request);
-    api.removeLocationUpdates();
+    delegate.requestLocationUpdates(request);
+    delegate.removeLocationUpdates();
     assertThat(shadowLocationManager.getRequestLocationUpdateListeners()).isEmpty();
   }
 
-  @Test public void requestLocationUpdates_shouldModifyOnlyClientListeners() {
-    client.connect();
-    api.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addListener(client, LocationRequest.create(),
-        new TestLocationListener());
-
-    otherClient.connect();
-
-    assertThat(clientManager.getLocationListeners().get(client).size()).isEqualTo(1);
-    assertThat(clientManager.getLocationListeners().get(otherClient)).isEmpty();
-  }
-
-  @Test public void requestLocationUpdates_shouldModifyOnlyClientPendingIntents() {
-    client.connect();
-    api.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addPendingIntent(client, LocationRequest.create(),
-        mock(PendingIntent.class));
-
-    otherClient.connect();
-
-    assertThat(clientManager.getPendingIntents().get(client).size()).isEqualTo(1);
-    assertThat(clientManager.getPendingIntents().get(otherClient)).isEmpty();
-  }
-
-  @Test public void requestLocationUpdates_shouldModifyOnlyClientLocationListeners() {
-    client.connect();
-    api.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addLocationCallback(client, LocationRequest.create(),
-        new TestLocationCallback(), Looper.myLooper());
-
-    otherClient.connect();
-
-    assertThat(clientManager.getLocationCallbacks().get(client).size()).isEqualTo(1);
-    assertThat(clientManager.getLocationCallbacks().get(otherClient)).isEmpty();
-  }
-
-  @Test public void removeLocationUpdates_shouldModifyOnlyClientPendingIntents() {
-    PendingIntent pendingIntent = mock(PendingIntent.class);
-    LocationRequest locationRequest = LocationRequest.create();
-
-    client.connect();
-    api.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addPendingIntent(client, locationRequest, pendingIntent);
-
-    otherClient.connect();
-    api.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addPendingIntent(otherClient, locationRequest, pendingIntent);
-
-    api.removeLocationUpdates();
-    LostClientManager.shared().removePendingIntent(client, pendingIntent);
-
-    assertThat(clientManager.getPendingIntents().get(client)).isEmpty();
-    assertThat(clientManager.getPendingIntents().get(otherClient).size()).isEqualTo(1);
-  }
-
-  @Test public void removeLocationUpdates_shouldModifyOnlyClientLocationListeners() {
-    TestLocationCallback callback = new TestLocationCallback();
-
-    client.connect();
-    api.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addLocationCallback(client, LocationRequest.create(), callback,
-        Looper.myLooper());
-
-    otherClient.connect();
-    api.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addLocationCallback(otherClient, LocationRequest.create(), callback,
-        Looper.myLooper());
-
-    LostClientManager.shared().removeLocationCallback(client, callback);
-    api.removeLocationUpdates();
-
-    assertThat(clientManager.getLocationCallbacks().get(client)).isEmpty();
-    assertThat(clientManager.getLocationCallbacks().get(otherClient).size()).isEqualTo(1);
-  }
-
-  @Test public void reportLocation_shouldNotifyClientListener() {
-    TestLocationListener listener = new TestLocationListener();
-    client.connect();
-    LostClientManager.shared().addListener(client, LocationRequest.create(), listener);
-
-    TestLocationListener otherListener = new TestLocationListener();
-    otherClient.connect();
-    LostClientManager.shared().addListener(otherClient, LocationRequest.create(), otherListener);
-    LostClientManager.shared().removeListener(otherClient, otherListener);
-
-    Location location = new Location("test");
-    api.reportLocation(location);
-
-    assertThat(listener.getAllLocations()).contains(location);
-    assertThat(otherListener.getAllLocations()).isEmpty();
-  }
-
-  @Test public void reportLocation_shouldNotifyPendingIntents() {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-
-    client.connect();
-    api.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addPendingIntent(client, LocationRequest.create(), pendingIntent);
-
-    PendingIntent otherPendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    otherClient.connect();
-    api.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addPendingIntent(otherClient, LocationRequest.create(),
-        otherPendingIntent);
-    LostClientManager.shared().removePendingIntent(otherClient, otherPendingIntent);
-    api.removeLocationUpdates();
-
-    Location location = new Location("test");
-    api.reportLocation(location);
-
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNull();
-  }
-
-  @Test public void reportLocation_shouldNotifyLocationCallbacks() {
-    TestLocationCallback callback = new TestLocationCallback();
-    client.connect();
-    api.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addLocationCallback(client, LocationRequest.create(), callback,
-        Looper.myLooper());
-
-    TestLocationCallback otherCallback = new TestLocationCallback();
-    otherClient.connect();
-    api.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addLocationCallback(otherClient, LocationRequest.create(),
-        otherCallback, Looper.myLooper());
-    api.removeLocationUpdates();
-    LostClientManager.shared().removeLocationCallback(otherClient, otherCallback);
-
-    api.reportProviderEnabled(GPS_PROVIDER);
-
-    assertThat(callback.getAvailability()).isNotNull();
-    assertThat(otherCallback.getAvailability()).isNull();
-  }
-
-  @Test public void reportLocation_shouldNotifyBothListeners() {
-    TestLocationListener listener = new TestLocationListener();
-    client.connect();
-    api.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addListener(client, LocationRequest.create(), listener);
-
-    TestLocationListener otherListener = new TestLocationListener();
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    api.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addListener(otherClient, otherRequest, otherListener);
-
-    Location location = new Location("test");
-    api.reportLocation(location);
-    assertThat(listener.getAllLocations()).contains(location);
-    assertThat(otherListener.getAllLocations()).contains(location);
-  }
-
-  @Test public void reportLocation_listener_shouldRespectFastestInterval() {
-    TestLocationListener listener = new TestLocationListener();
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(1000);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
-
-    TestLocationListener otherListener = new TestLocationListener();
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    api.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addListener(otherClient, otherRequest, otherListener);
-
-    api.reportLocation(new Location("test"));
-    listener.getAllLocations().clear();
-    otherListener.getAllLocations().clear();
-
-    Location location = new Location("test");
-    api.reportLocation(location);
-    assertThat(listener.getAllLocations()).isEmpty();
-    assertThat(otherListener.getAllLocations().size()).isEqualTo(1);
-  }
-
-  @Test public void reportLocation_listener_shouldRespectSmallestDisplacement() {
-    TestLocationListener listener = new TestLocationListener();
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setSmallestDisplacement(10);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
-
-    TestLocationListener otherListener = new TestLocationListener();
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    api.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addListener(otherClient, otherRequest, otherListener);
-
-    api.reportLocation(new Location("test"));
-    listener.getAllLocations().clear();
-    otherListener.getAllLocations().clear();
-
-    Location location = new Location("test");
-    api.reportLocation(location);
-    assertThat(listener.getAllLocations()).isEmpty();
-    assertThat(otherListener.getAllLocations().size()).isEqualTo(1);
-  }
-
-  @Test public void reportLocation_listener_shouldRespectLargestIntervalAndSmallestDisplacement()
-      throws InterruptedException {
-    TestLocationListener listener = new TestLocationListener();
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(1000);
-    request.setSmallestDisplacement(10);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addListener(client, request, listener);
-
-    TestLocationListener otherListener = new TestLocationListener();
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    api.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addListener(otherClient, otherRequest, otherListener);
-
-    api.reportLocation(new Location("test"));
-    listener.getAllLocations().clear();
-    otherListener.getAllLocations().clear();
-
-    Location location = new Location("test");
-    location.setLatitude(70.0);
-    location.setLongitude(40.0);
-    api.reportLocation(location);
-    assertThat(listener.getAllLocations()).isEmpty();
-    assertThat(otherListener.getAllLocations().size()).isEqualTo(1);
-
-    api.reportLocation(new Location("test"));
-    assertThat(listener.getAllLocations()).isEmpty();
-    assertThat(otherListener.getAllLocations().size()).isEqualTo(2);
-
-    Thread.sleep(1000);
-    api.reportLocation(location);
-    assertThat(listener.getAllLocations().size()).isEqualTo(1);
-    assertThat(otherListener.getAllLocations().size()).isEqualTo(3);
-  }
-
-  @Test public void reportLocation_shouldNotifyBothPendingIntents() {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    client.connect();
-    api.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addPendingIntent(client, LocationRequest.create(), pendingIntent);
-
-    Intent otherIntent = new Intent(application, TestService.class);
-    PendingIntent otherPendingIntent = PendingIntent.getService(application, 0, otherIntent, 0);
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    api.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addPendingIntent(otherClient, LocationRequest.create(),
-        otherPendingIntent);
-
-    Location location = new Location("test");
-    api.reportLocation(location);
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-  }
-
-  @Test public void reportLocation_pendingIntent_shouldRespectFastestInterval() {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(1000);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addPendingIntent(client, request, pendingIntent);
-
-    Intent otherIntent = new Intent(application, TestService.class);
-    PendingIntent otherPendingIntent = PendingIntent.getService(application, 0, otherIntent, 0);
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    api.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addPendingIntent(otherClient, otherRequest, otherPendingIntent);
-
-    api.reportLocation(new Location("test"));
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-
-    Location location = new Location("test");
-    api.reportLocation(location);
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNull();
-  }
-
-  @Test public void reportLocation_pendingIntent_shouldRespectSmallestDisplacement() {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(1000);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addPendingIntent(client, request, pendingIntent);
-
-    Intent otherIntent = new Intent(application, TestService.class);
-    PendingIntent otherPendingIntent = PendingIntent.getService(application, 0, otherIntent, 0);
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    api.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addPendingIntent(otherClient, otherRequest, otherPendingIntent);
-
-    api.reportLocation(new Location("test"));
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-
-    Location location = new Location("test");
-    api.reportLocation(location);
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNull();
-  }
-
-  @Test public void reportLocation_pendingIntent_shouldRespectLargestIntervalSmallestDisplacement()
-      throws InterruptedException {
-    Intent intent = new Intent(application, TestService.class);
-    PendingIntent pendingIntent = PendingIntent.getService(application, 0, intent, 0);
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(1000);
-    request.setSmallestDisplacement(10);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addPendingIntent(client, request, pendingIntent);
-
-    Intent otherIntent = new Intent(application, TestService.class);
-    PendingIntent otherPendingIntent = PendingIntent.getService(application, 0, otherIntent, 0);
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    api.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addPendingIntent(otherClient, otherRequest, otherPendingIntent);
-
-    api.reportLocation(new Location("test"));
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-
-    Location location = new Location("test");
-    location.setLatitude(70.0);
-    location.setLongitude(40.0);
-    api.reportLocation(location);
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNull();
-
-    api.reportLocation(new Location("test"));
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNull();
-
-    Thread.sleep(1000);
-    api.reportLocation(location);
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-    assertThat(ShadowApplication.getInstance().getNextStartedService()).isNotNull();
-  }
-
-  @Test public void reportLocation_shouldNotifyBothCallbacks() {
-    TestLocationCallback callback = new TestLocationCallback();
-    client.connect();
-    api.requestLocationUpdates(LocationRequest.create());
-    LostClientManager.shared().addLocationCallback(client, LocationRequest.create(), callback,
-        Looper.myLooper());
-
-    TestLocationCallback otherCallback = new TestLocationCallback();
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    api.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addLocationCallback(otherClient, LocationRequest.create(),
-        otherCallback, Looper.myLooper());
-
-    Location location = new Location("test");
-    api.reportLocation(location);
-    assertThat(callback.getResult()).isNotNull();
-    assertThat(otherCallback.getResult()).isNotNull();
-  }
-
-  @Test public void reportLocation_callback_shouldRespectFastestInterval() {
-    TestLocationCallback callback = new TestLocationCallback();
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(1000);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addLocationCallback(client, request, callback, Looper.myLooper());
-
-    TestLocationCallback otherCallback = new TestLocationCallback();
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    api.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addLocationCallback(otherClient, otherRequest, otherCallback,
-        Looper.myLooper());
-
-    api.reportLocation(new Location("test"));
-    callback.setResult(null);
-    otherCallback.setResult(null);
-
-    Location location = new Location("test");
-    api.reportLocation(location);
-    assertThat(callback.getResult()).isNull();
-    assertThat(otherCallback.getResult()).isNotNull();
-  }
-
-  @Test public void reportLocation_callback_shouldRespectSmallestDisplacement() {
-    TestLocationCallback callback = new TestLocationCallback();
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setSmallestDisplacement(10);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addLocationCallback(client, request, callback, Looper.myLooper());
-
-    TestLocationCallback otherCallback = new TestLocationCallback();
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    api.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addLocationCallback(otherClient, otherRequest, otherCallback,
-        Looper.myLooper());
-
-    api.reportLocation(new Location("test"));
-    callback.setResult(null);
-    otherCallback.setResult(null);
-
-    Location location = new Location("test");
-    api.reportLocation(location);
-    assertThat(callback.getResult()).isNull();
-    assertThat(otherCallback.getResult()).isNotNull();
-  }
-
-  @Test public void reportLocation_callback_shouldRespectLargestIntervalAndSmallestDisplacement()
-      throws InterruptedException {
-    TestLocationCallback callback = new TestLocationCallback();
-    client.connect();
-    LocationRequest request = LocationRequest.create();
-    request.setFastestInterval(1000);
-    request.setSmallestDisplacement(10);
-    api.requestLocationUpdates(request);
-    LostClientManager.shared().addLocationCallback(client, request, callback, Looper.myLooper());
-
-    TestLocationCallback otherCallback = new TestLocationCallback();
-    otherClient.connect();
-    LocationRequest otherRequest = LocationRequest.create();
-    otherRequest.setFastestInterval(0);
-    api.requestLocationUpdates(otherRequest);
-    LostClientManager.shared().addLocationCallback(otherClient, otherRequest, otherCallback,
-        Looper.myLooper());
-
-    api.reportLocation(new Location("test"));
-    callback.setResult(null);
-    otherCallback.setResult(null);
-
-    Location location = new Location("test");
-    location.setLatitude(70.0);
-    location.setLongitude(40.0);
-    api.reportLocation(location);
-    assertThat(callback.getResult()).isNull();
-    assertThat(otherCallback.getResult()).isNotNull();
-
-    api.reportLocation(new Location("test"));
-    assertThat(callback.getResult()).isNull();
-    assertThat(otherCallback.getResult()).isNotNull();
-
-    Thread.sleep(1000);
-    api.reportLocation(location);
-    assertThat(callback.getResult()).isNotNull();
-    assertThat(otherCallback.getResult()).isNotNull();
+  @Test public void reportProviderEnabled_shouldNotifyAvailabilityChanged() throws Exception {
+    TestFusedLocationProviderCallback callback = new TestFusedLocationProviderCallback();
+    delegate.init(callback);
+    delegate.reportProviderEnabled(GPS_PROVIDER);
+    assertThat(callback.locationAvailability).isNotNull();
   }
 
   public class TestService extends IntentService {
@@ -1084,6 +365,24 @@ public class FusedLocationProviderServiceDelegateTest extends BaseRobolectricTes
     }
 
     @Override protected void onHandleIntent(Intent intent) {
+    }
+  }
+
+  public class TestFusedLocationProviderCallback implements IFusedLocationProviderCallback {
+    private Location location;
+    private LocationAvailability locationAvailability;
+
+    @Override public void onLocationChanged(Location location) throws RemoteException {
+      this.location = location;
+    }
+
+    @Override public void onLocationAvailabilityChanged(LocationAvailability locationAvailability)
+        throws RemoteException {
+      this.locationAvailability = locationAvailability;
+    }
+
+    @Override public IBinder asBinder() {
+      return null;
     }
   }
 }

--- a/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
+++ b/lost/src/test/java/com/mapzen/android/lost/internal/LostApiClientImplTest.java
@@ -14,14 +14,12 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import android.content.ComponentName;
 import android.location.Location;
 import android.location.LocationManager;
 
 import static android.content.Context.LOCATION_SERVICE;
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.robolectric.RuntimeEnvironment.application;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -35,12 +33,6 @@ public class LostApiClientImplTest extends BaseRobolectricTest {
     LostClientManager.shared().clearClients();
     callbacks = new TestConnectionCallbacks();
     client = new LostApiClientImpl(application, callbacks, LostClientManager.shared());
-
-    FusedLocationProviderService.FusedLocationProviderBinder stubBinder =
-        mock(FusedLocationProviderService.FusedLocationProviderBinder.class);
-    when(stubBinder.getService()).thenReturn(mock(FusedLocationProviderService.class));
-    shadowOf(application).setComponentNameAndServiceForBindService(
-        new ComponentName("com.mapzen.lost", "FusedLocationProviderService"), stubBinder);
   }
 
   @After public void tearDown() throws Exception {
@@ -149,6 +141,8 @@ public class LostApiClientImplTest extends BaseRobolectricTest {
 
   @Test public void disconnect_shouldUnregisterLocationUpdateListeners() throws Exception {
     client.connect();
+    ((FusedLocationProviderApiImpl) LocationServices.FusedLocationApi).service =
+        mock(IFusedLocationProviderService.class);
     LocationServices.FusedLocationApi.requestLocationUpdates(client, LocationRequest.create(),
         new LocationListener() {
           @Override public void onLocationChanged(Location location) {


### PR DESCRIPTION
* Adds AIDL interface for FusedLocationProviderService

* Use service context looper when registering for location manager updates

* Delivers location updates via AIDL callback interface

* Notifies location availability changes via AIDL callback

* Shutdown location updates if all listeners have been removed

* Move fused location provider service into its own process

* Migrates remaining logic for tracking location updates from service to client manager

### Overview

### Proposed Changes
